### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,17 +1,17 @@
-NTP KEYWORD1
-begin KEYWORD2
-get_unix_time() KEYWORD2
-get_hour KEYWORD2
-get_minutes KEYWORD2
-get_secons KEYWORD2
-get_day KEYWORD2
-get_month KEYWORD2
-get_year KEYWORD2
-get_timeNow KEYWORD2
-get_data KEYWORD2
-get_time_mode KEYWORD2
-onTime KEYWORD2
-ajusteHorario KEYWORD2
+NTP	KEYWORD1
+begin	KEYWORD2
+get_unix_time()	KEYWORD2
+get_hour	KEYWORD2
+get_minutes	KEYWORD2
+get_secons	KEYWORD2
+get_day	KEYWORD2
+get_month	KEYWORD2
+get_year	KEYWORD2
+get_timeNow	KEYWORD2
+get_data	KEYWORD2
+get_time_mode	KEYWORD2
+onTime	KEYWORD2
+ajusteHorario	KEYWORD2
 
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords