### PR TITLE
Correct invalid keyword in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
 NTP	KEYWORD1
 begin	KEYWORD2
-get_unix_time()	KEYWORD2
+get_unix_time	KEYWORD2
 get_hour	KEYWORD2
 get_minutes	KEYWORD2
 get_secons	KEYWORD2


### PR DESCRIPTION
The parentheses on get_unix_time() caused the Arduino IDE to not recognize the keyword.